### PR TITLE
Fix JWT header in integration test

### DIFF
--- a/src/test/java/com/moneport/jwt/JwtAuthenticationIntegrationTest.java
+++ b/src/test/java/com/moneport/jwt/JwtAuthenticationIntegrationTest.java
@@ -30,7 +30,7 @@ public class JwtAuthenticationIntegrationTest {
 
         // when + then
         mockMvc.perform(get("/api/auth/secure")  // JWT 인증이 필요한 API
-                        .header("Authorization", token)
+                        .header("Authorization", "Bearer " + token)
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.msg").value("인증된 사용자만 볼 수 있습니다."));


### PR DESCRIPTION
## Summary
- ensure integration test sends a proper Bearer token

## Testing
- `gradle test --offline` *(fails: Plugin [id: 'org.springframework.boot', version: '3.4.4'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d085acef0832eb7b9927e090abed6